### PR TITLE
add travis integration and example-based testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: python
 python: 2.7
 
 install:
-  - python setup.py sdist bdist_wheel install
+  - pip install -e .
 
 script:
-  - pytest
+  - python setup.py sdist
+  - python setup.py bdist_wheel
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ sudo: false
 language: python
 python: 2.7
 
-install:
-  - pip install -e .
-
 script:
   - python setup.py sdist
   - python setup.py bdist_wheel
-
+  - python setup.py install
+  - tests/setup_examples.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: python
+python: 2.7
+
+install:
+  - python setup.py sdist bdist_wheel install
+
+script:
+  - pytest

--- a/examples/examplelibrary2/examplepackage2/examplemodule2.py
+++ b/examples/examplelibrary2/examplepackage2/examplemodule2.py
@@ -14,11 +14,11 @@ if __name__ == '__main__':
     # are we in a or b variant?
     try:
         import a_only
-        print "we are probably in '2a' variant"
+        print "we are in '2a' variant"
     except:
         pass
     try:
         import b_only
-        print "we are probably in '2b' variant"
+        print "we are in '2b' variant"
     except:
         pass

--- a/tests/setup_examples.sh
+++ b/tests/setup_examples.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -e
+
+cd $(dirname $0)/../examples
+
+pip_uninstall_examples() {
+    for pkg in examplelibrary examplelibrary_2a examplelibrary_2b; do
+        pip uninstall -y $pkg || true
+    done
+}
+
+# examplelibrary
+cd examplelibrary
+rm -rf build dist
+pip_uninstall_examples
+python setup.py sdist
+pip install dist/examplelibrary-*.tar.gz
+pushd /tmp
+python -c 'import examplepackage.examplemodule; examplepackage.examplemodule.example_function(); print examplepackage.examplemodule'
+examplescript foo bar baz | grep "doing something on \['foo', 'bar', 'baz'\]"
+popd
+cd ..
+
+# examplelibrary_2a
+cd examplelibrary2
+rm -rf build dist
+pip_uninstall_examples
+python setup_examplelibrary_2a.py sdist
+pip install dist/examplelibrary_2a-*.tar.gz
+pushd /tmp
+python -c 'import examplepackage2; print examplepackage2'
+examplescript2a | grep "we are in '2a' variant"
+popd
+cd ..
+
+# examplelibrary_2b
+cd examplelibrary2
+rm -rf build dist
+pip_uninstall_examples
+python subdir/setup_examplelibrary_2b.py sdist
+pip install dist/examplelibrary_2b-*.tar.gz
+pushd /tmp
+python -c 'import examplepackage2; print examplepackage2'
+examplescript2b | grep "we are in '2b' variant"
+popd
+cd ..


### PR DESCRIPTION
pretty simple usage of the quicklib installed library for building, installing and testing the provided example libraries.